### PR TITLE
aggregator: export various metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ $ curl -H "Authorization: Basic <base64_encoded_token>" http://localhost:8083/v1
 | **nomad-server** | string | no | `http://localhost:4646` | HTTP API address of a Nomad server or agent. |
 | **node-attribute** | []string | no | N/A | Aggregator will filter nodes based on these attributes. E.g. if you set `os.name=ubuntu`, aggregator will only reach out to ubuntu nodes in the cluster. |
 | **threshold-percentage** | int | no | `85` | If the number of eligible nodes goes below the threshold, `npd` will stop marking nodes as ineligible. |
+| **prometheus-server-port** | int | no | `3000` | The port used to expose aggregator metrics in the prometheus format |
+| **prometheus-server-addr** | string | no | `0.0.0.0` | The address to bind the aggregator metrics exporter |
 
 **Detector** - Run nomad node problem detector HTTP server
 

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -353,7 +353,6 @@ func aggregate(context *cli.Context) error {
 						continue
 					} else {
 						stateChanged = true
-						healthCheckStateChangedCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address}).Inc()
 					}
 				}
 			}

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -329,7 +329,7 @@ func aggregate(context *cli.Context) error {
 				if curr.Result == "Unhealthy" || curr.Result == "true" {
 					log.Warning(fmt.Sprintf("Node %s: %s is %s: %s\n", node.Address, curr.Type, curr.Result, curr.Message))
 					nodeHealthy = false
-					healthCheckUnhealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address}).Inc()
+					healthCheckUnhealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address, "message": curr.Message}).Inc()
 
 					// Even if one of the health checks are failing, node will not be taken out of the scheduling pool.
 					// Unless that health check is part of --enforce-health-check list.

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -329,7 +329,8 @@ func aggregate(context *cli.Context) error {
 				if curr.Result == "Unhealthy" || curr.Result == "true" {
 					log.Warning(fmt.Sprintf("Node %s: %s is %s: %s\n", node.Address, curr.Type, curr.Result, curr.Message))
 					nodeHealthy = false
-					nodeUnhealthyCounter.With(prometheus.Labels{"dc": datacenter}).Inc()
+					healthCheckUnhealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address}).Inc()
+
 					// Even if one of the health checks are failing, node will not be taken out of the scheduling pool.
 					// Unless that health check is part of --enforce-health-check list.
 					// Set toggle=true if above is satisfied.
@@ -340,7 +341,7 @@ func aggregate(context *cli.Context) error {
 						log.Info(fmt.Sprintf("%s is not in enforce health check list. Node %s will be dry-runned and not taken out of scheduling pool\n", curr.Type, node.Address))
 					}
 				} else {
-					nodeHealthyCounter.With(prometheus.Labels{"dc": datacenter}).Inc()
+					healthCheckHealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type}).Inc()
 					if debug {
 						log.Debug(fmt.Sprintf("Node %s: %s is %s: %s\n", node.Address, curr.Type, curr.Result, curr.Message))
 					}
@@ -352,7 +353,7 @@ func aggregate(context *cli.Context) error {
 						continue
 					} else {
 						stateChanged = true
-						nodeHealthStateChangedCounter.With(prometheus.Labels{"dc": datacenter}).Inc()
+						healthCheckStateChangedCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address}).Inc()
 					}
 				}
 			}

--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -1,0 +1,96 @@
+package aggregator
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	aggregatorCyclesTotalCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aggregator_cycles_total",
+			Help: "Number of cycles",
+		}, []string{"dc"})
+
+	aggregatorProcessingTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "aggregator_processing_time",
+			Help: "time spend aggregating information for this cycle",
+		}, []string{"dc"})
+
+	nodesTotalGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nodes_total",
+			Help: "Total number of nodes",
+		}, []string{"dc"})
+
+	eligibleNodesGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nodes_eligible",
+			Help: "Number of eligible nodes for this cycle",
+		}, []string{"dc"})
+
+	nodeHandleErrorsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_handle_errors",
+			Help: "Count of errors while handling a node",
+		}, []string{"dc"})
+
+	nodeHandleSkipCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_handle_skips",
+			Help: "Count of nodes skipped",
+		}, []string{"dc"})
+
+	nodeHealthyCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_healthy",
+			Help: "Count of healthy nodes",
+		}, []string{"dc"})
+
+	nodeUnhealthyCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_unhealthy",
+			Help: "Count of unhealthy nodes",
+		}, []string{"dc"})
+
+	nodeHealthStateChangedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_health_state_changes",
+			Help: "Count of hosts whose states has changed",
+		}, []string{"dc"})
+)
+
+func registerMetrics() *prometheus.Registry {
+	r := prometheus.NewRegistry()
+	r.MustRegister(aggregatorCyclesTotalCounter)
+	r.MustRegister(aggregatorProcessingTime)
+	r.MustRegister(eligibleNodesGauge)
+	r.MustRegister(nodesTotalGauge)
+	r.MustRegister(nodeHandleErrorsCounter)
+	r.MustRegister(nodeHandleSkipCounter)
+	r.MustRegister(nodeHealthyCounter)
+	r.MustRegister(nodeUnhealthyCounter)
+	r.MustRegister(nodeHealthStateChangedCounter)
+	r.MustRegister(prometheus.NewGoCollector())
+	r.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	return r
+}
+
+func metricsExporter(exporterAddr string, exporterPort int) {
+	addr := net.JoinHostPort(exporterAddr, strconv.Itoa(exporterPort))
+
+	registry := registerMetrics()
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			log.Fatalf("Failed to start Prometheus scrape endpoint: %v", err)
+		}
+	}()
+}

--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -43,27 +43,27 @@ var (
 
 	nodeHandleSkipCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_handle_skips",
+			Name: "node_handle_skip",
 			Help: "Count of nodes skipped",
 		}, []string{"dc"})
 
-	nodeHealthyCounter = prometheus.NewCounterVec(
+	healthCheckHealthyCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "node_healthy",
 			Help: "Count of healthy nodes",
-		}, []string{"dc"})
+		}, []string{"dc", "check"})
 
-	nodeUnhealthyCounter = prometheus.NewCounterVec(
+	healthCheckUnhealthyCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "node_unhealthy",
 			Help: "Count of unhealthy nodes",
-		}, []string{"dc"})
+		}, []string{"dc", "check", "host"})
 
-	nodeHealthStateChangedCounter = prometheus.NewCounterVec(
+	healthCheckStateChangedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "node_health_state_changes",
 			Help: "Count of hosts whose states has changed",
-		}, []string{"dc"})
+		}, []string{"dc", "check", "host"})
 )
 
 func registerMetrics() *prometheus.Registry {
@@ -74,9 +74,9 @@ func registerMetrics() *prometheus.Registry {
 	r.MustRegister(nodesTotalGauge)
 	r.MustRegister(nodeHandleErrorsCounter)
 	r.MustRegister(nodeHandleSkipCounter)
-	r.MustRegister(nodeHealthyCounter)
-	r.MustRegister(nodeUnhealthyCounter)
-	r.MustRegister(nodeHealthStateChangedCounter)
+	r.MustRegister(healthCheckHealthyCounter)
+	r.MustRegister(healthCheckUnhealthyCounter)
+	r.MustRegister(healthCheckStateChangedCounter)
 	r.MustRegister(prometheus.NewGoCollector())
 	r.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	return r

--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -58,12 +58,6 @@ var (
 			Name: "node_unhealthy",
 			Help: "Count of unhealthy nodes",
 		}, []string{"dc", "check", "host"})
-
-	healthCheckStateChangedCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "node_health_state_changes",
-			Help: "Count of hosts whose states has changed",
-		}, []string{"dc", "check", "host"})
 )
 
 func registerMetrics() *prometheus.Registry {
@@ -76,7 +70,6 @@ func registerMetrics() *prometheus.Registry {
 	r.MustRegister(nodeHandleSkipCounter)
 	r.MustRegister(healthCheckHealthyCounter)
 	r.MustRegister(healthCheckUnhealthyCounter)
-	r.MustRegister(healthCheckStateChangedCounter)
 	r.MustRegister(prometheus.NewGoCollector())
 	r.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	return r

--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -57,7 +57,7 @@ var (
 		prometheus.CounterOpts{
 			Name: "node_unhealthy",
 			Help: "Count of unhealthy nodes",
-		}, []string{"dc", "check", "host"})
+		}, []string{"dc", "check", "host", "message"})
 )
 
 func registerMetrics() *prometheus.Registry {


### PR DESCRIPTION
Add two new arguments to the aggregator, to configure the address and
port the HTTP endpoint will use to expose metrics. By default, the
server binds on all interfaces and on port 3000.

There's a number of metrics being exposed. The first two are runtime
metrics (process and go's runtime).

The application specific metrics are:

- aggregator_cycles_total: the total number of cycles the aggregator has
  gone  through - this metric can be used to ensure the aggregator is
  still  making progress

- aggregator_processing_time: how long the aggregator spend during the
  most recent cycle. This metric can be used to detect possible
  degradation in performance of the aggregator

- nodes_total: how many nodes are returned by nomad this cycle

- nodes_eligible: how many nodes are eligible this cycle

- node_handle_errors: how many errors while processing the nodes - this
  metric can be used to detect spikes in failures, or to ensure the
  aggregator is not failing on a large number of hosts

- node_handle_skips: how many nodes have been skipped - this metric can
  be used to detect spiked in hosts where the detector is not working

- node_healthy: how many nodes are marked as healthy - this metric
  can be used to ensure that the majority of hosts are healthy. This can
  be used as a baseline for an SLO (e.g. 99% of the hosts in the cluster
  are reported as healthy)

- node_unhealthy: how many nodes are marked as unhealthy. This metric
  can be used to detect spikes in hosts becoming unhealthy, or slow
  degradation over time (e.g. 2% of the hosts have become unhealthy in
  the last 24 hours)

- node_health_state_changes: how many nodes have their health state
  changed. A sudden change in this metric can help surfacing possible
  network or infrastructure errors