### PR TITLE
metrics: remove 'message' from the labels

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -329,7 +329,7 @@ func aggregate(context *cli.Context) error {
 				if curr.Result == "Unhealthy" || curr.Result == "true" {
 					log.Warning(fmt.Sprintf("Node %s: %s is %s: %s\n", node.Address, curr.Type, curr.Result, curr.Message))
 					nodeHealthy = false
-					healthCheckUnhealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address, "message": curr.Message}).Inc()
+					healthCheckUnhealthyCounter.With(prometheus.Labels{"dc": datacenter, "check": curr.Type, "host": node.Address}).Inc()
 
 					// Even if one of the health checks are failing, node will not be taken out of the scheduling pool.
 					// Unless that health check is part of --enforce-health-check list.

--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -37,27 +37,27 @@ var (
 
 	nodeHandleErrorsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_handle_errors",
-			Help: "Count of errors while handling a node",
+			Name: "nodes_handle_errors",
+			Help: "Count of errors while handling nodes",
 		}, []string{"dc"})
 
 	nodeHandleSkipCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_handle_skip",
+			Name: "nodes_handle_skip",
 			Help: "Count of nodes skipped",
 		}, []string{"dc"})
 
 	healthCheckHealthyCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_healthy",
+			Name: "nodes_healthy",
 			Help: "Count of healthy nodes",
 		}, []string{"dc", "check"})
 
 	healthCheckUnhealthyCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_unhealthy",
+			Name: "nodes_unhealthy",
 			Help: "Count of unhealthy nodes",
-		}, []string{"dc", "check", "host", "message"})
+		}, []string{"dc", "check", "host"})
 )
 
 func registerMetrics() *prometheus.Registry {


### PR DESCRIPTION
For unhealthy nodes, we don't need to use the message from a failed
check as a label. This information is already logged, we can rely on
that if we need to know the reason.

Use plural form for the name of the metrics, to be consistent.