### PR TITLE
feat(build): add build information to the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ export GO111MODULE=on
 export NOMAD_ADDR=http://localhost:4646
 export NOMAD_E2E=1
 
+GIT_VERSION?=$(shell git describe --always --dirty --tags)
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_DATE ?= $(shell date +%s)
+
+LDFLAGS += -X 'main.Timestamp=${BUILD_DATE}'
+LDFLAGS += -X 'main.GitCommit=${GIT_COMMIT}'
+LDFLAGS += -X 'main.GitVersion=${GIT_VERSION}'
+
 default: build
 
 .PHONY: clean
@@ -17,11 +25,10 @@ clean:
 
 .PHONY: build
 build:
-	$(GOLANG) build -o $(BINARY) .
+	$(GOLANG) build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 .PHONY: install
-install:
-	$(GOLANG) build -o $(BINARY) .
+install: build
 	install -m 755 $(BINARY) $(BINDIR)/$(BINARY)
 
 .PHONY: test

--- a/main.go
+++ b/main.go
@@ -18,9 +18,12 @@ limitations under the License.
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
 	"os"
+	"strconv"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	aggregator "github.com/nomad-node-problem-detector/aggregator"
 	config "github.com/nomad-node-problem-detector/config"
@@ -28,12 +31,25 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var (
+	Timestamp  string
+	GitCommit  string
+	GitVersion string
+)
+
 func main() {
+	// convert the timestamp to a date time to populate correctly the
+	// information for the app
+	i, err := strconv.ParseInt(Timestamp, 10, 64)
+	if err != nil {
+		log.Fatalf("failed to convert %s to an integer: %v", Timestamp, err)
+	}
+
 	app := &cli.App{
 		Name:                 "npd",
 		Usage:                "Nomad node problem detector",
-		Version:              "v1.0.0",
-		Compiled:             time.Now(),
+		Version:              fmt.Sprintf("%s (%s)", GitVersion, GitCommit),
+		Compiled:             time.Unix(i, 0),
 		EnableBashCompletion: true,
 		Authors: []*cli.Author{
 			{
@@ -48,7 +64,7 @@ func main() {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Add information about the version and the build time to the binary. This
is useful to validate which version of the binary is being deployed on a
host. Running `npd --version` will show the commit used when the binary
is build.