### PR TITLE
fcuny/aggregator build information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ export GO111MODULE=on
 export NOMAD_ADDR=http://localhost:4646
 export NOMAD_E2E=1
 
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_DATE ?= $(shell date +%s)
+
+LDFLAGS += -X 'main.Timestamp=${BUILD_DATE}'
+LDFLAGS += -X 'main.GitCommit=${GIT_COMMIT}'
+
 default: build
 
 .PHONY: clean
@@ -17,7 +23,7 @@ clean:
 
 .PHONY: build
 build:
-	$(GOLANG) build -o $(BINARY) .
+	$(GOLANG) build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 .PHONY: install
 install:

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -169,7 +169,7 @@ func aggregate(context *cli.Context) error {
 	signal.Notify(sigs, syscall.SIGUSR1)
 	go flipPause(sigs)
 
-	metricsExporter(context.String("prometheus-server-addr"), context.Int("prometheus-server-port"))
+	metricsExporter(context.String("prometheus-server-addr"), context.Int("prometheus-server-port"), context.App.Version)
 
 	nodeHandle := client.Nodes()
 

--- a/main.go
+++ b/main.go
@@ -18,9 +18,12 @@ limitations under the License.
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
 	"os"
+	"strconv"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	aggregator "github.com/nomad-node-problem-detector/aggregator"
 	config "github.com/nomad-node-problem-detector/config"
@@ -28,12 +31,25 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var (
+	Timestamp string
+	GitCommit string
+)
+
 func main() {
+	// convert the timestamp to a date time to populate correctly the
+	// information for the app
+	i, err := strconv.ParseInt(Timestamp, 10, 64)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert %s to an integer: %v", Timestamp, err))
+	}
+	compiledAt := time.Unix(i, 0)
+
 	app := &cli.App{
 		Name:                 "npd",
 		Usage:                "Nomad node problem detector",
-		Version:              "v1.0.0",
-		Compiled:             time.Now(),
+		Version:              GitCommit,
+		Compiled:             compiledAt,
 		EnableBashCompletion: true,
 		Authors: []*cli.Author{
 			{
@@ -48,7 +64,7 @@ func main() {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Similar to what prometheus does for exporting information about Go, this
change adds some build information to the metrics for the aggregator.
This can be useful to ensure we're using the latest version, or if we're
running multiple versions in production.

This is the output (showing both go and npd info):
```
$ curl -s localhost:3000/metrics|grep _info
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.16.5"} 1
# HELP npd_aggregator_info Information about the npd aggregator
# TYPE npd_aggregator_info gauge
npd_aggregator_info{version="a08e2c16d59e12e61cf262711c486bc480edc547"} 1
```