### PR TITLE
feat(version): add build information to the metrics and startup

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -169,7 +169,7 @@ func aggregate(context *cli.Context) error {
 	signal.Notify(sigs, syscall.SIGUSR1)
 	go flipPause(sigs)
 
-	metricsExporter(context.String("prometheus-server-addr"), context.Int("prometheus-server-port"))
+	metricsExporter(context.String("prometheus-server-addr"), context.Int("prometheus-server-port"), context.App.Version)
 
 	nodeHandle := client.Nodes()
 


### PR DESCRIPTION
Similar to what prometheus does for exporting information about Go, this
change adds some build information to the metrics for the aggregator and
the detectors.

This can be useful to ensure we're using the latest version, or if we're
running multiple versions in production.

This is the output (showing both go and npd info):
```
$ curl -s localhost:3000/metrics|grep _info
go_info{version="go1.16.5"} 1
npd_aggregator_info{version="a08e2c16d59e12e61cf262711c486bc480edc547"} 1
```

The version is also displayed in the log when the process starts.