### PR TITLE
style: address a number of reports from the linter

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -142,7 +142,7 @@ func aggregate(context *cli.Context) error {
 	for _, attribute := range nodeAttributes {
 		result := strings.Split(attribute, "=")
 		if len(result) != 2 {
-			return fmt.Errorf("Invalid --node-attribute. Set key=val for valid node attribute.")
+			return fmt.Errorf("invalid --node-attribute. Set key=val for valid node attribute")
 		}
 		nodeAttributesMap[result[0]] = result[1]
 	}
@@ -161,7 +161,7 @@ func aggregate(context *cli.Context) error {
 	// when reaching out to npd detectors.
 	datacenter := os.Getenv("NOMAD_DC")
 	if datacenter == "" {
-		return fmt.Errorf("NOMAD_DC environment variable missing. Datacenter must be set.")
+		return fmt.Errorf("the environment variable `NOMAD_DC' is missing. Datacenter must be set")
 	}
 	detectorDCMap[datacenter] = true
 
@@ -393,7 +393,6 @@ func aggregate(context *cli.Context) error {
 
 		time.Sleep(aggregationCycleTime)
 	}
-	return nil
 }
 
 // getEligibleNodeCount return the count of eligible nodes.
@@ -452,15 +451,12 @@ func isNpdServerActive(npdServer, authToken string) (bool, error) {
 
 // flipPause pauses and unpauses aggregator based on receiving SIGUSR1 signal.
 func flipPause(sigs chan os.Signal) {
-	for {
-		select {
-		case <-sigs:
-			pause = !pause
-			if pause {
-				log.Info("Received signal SIGUSR1, pausing aggregator.")
-			} else {
-				log.Info("Received signal SIGUSR1, unpausing aggregator.")
-			}
+	for range sigs {
+		pause = !pause
+		if pause {
+			log.Info("Received signal SIGUSR1, pausing aggregator.")
+		} else {
+			log.Info("Received signal SIGUSR1, unpausing aggregator.")
 		}
 	}
 }

--- a/build/image_build.go
+++ b/build/image_build.go
@@ -52,7 +52,7 @@ func BuildImage(imageName, rootDir string) error {
 	}
 
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return err
 	}
@@ -76,6 +76,10 @@ func BuildImage(imageName, rootDir string) error {
 	buildContext.Close()
 
 	dockerBuildContext, err := os.Open(tmpDir + "/buildContext.tar")
+	if err != nil {
+		return err
+	}
+
 	defer dockerBuildContext.Close()
 
 	options := types.ImageBuildOptions{

--- a/build/tar.go
+++ b/build/tar.go
@@ -11,7 +11,7 @@ import (
 
 func tarDir(destinationFilename, sourceDir string) error {
 	if destinationFilename[len(destinationFilename)-3:] != "tar" {
-		return fmt.Errorf("Please provide a valid tar filename")
+		return fmt.Errorf("please provide a valid tar filename")
 	}
 
 	tarFile, err := os.Create(destinationFilename)

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ func buildConfig(context *cli.Context) error {
 	configFilePath := rootDir + "/config.json"
 	if _, err := os.Stat(configFilePath); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("config.json missing in --root-dir: %s. npd config build -h for help\n", rootDir)
+			return fmt.Errorf("config.json missing in --root-dir: %s. npd config build -h for help", rootDir)
 		}
 		return err
 	}
@@ -167,11 +167,11 @@ func generateConfig(context *cli.Context) error {
 		}
 
 		if len(hcFiles) == 0 {
-			return fmt.Errorf("Health check missing in %s directory.", healthCheckDir)
+			return fmt.Errorf("health check missing in %s directory", healthCheckDir)
 		}
 
 		if len(hcFiles) > 1 {
-			return fmt.Errorf("There should be only 1 health check present in the %s directory.\nIf health checks are present at a different location, use --root-dir to set the location. npd config generate --help for more details.\n", healthCheckDir)
+			return fmt.Errorf("there should be only 1 health check present in the %s directory.\nIf health checks are present at a different location, use --root-dir to set the location. npd config generate --help for more details", healthCheckDir)
 		}
 
 		res.HealthCheck = hcFiles[0].Name()
@@ -179,7 +179,7 @@ func generateConfig(context *cli.Context) error {
 	}
 
 	if !directoryExists {
-		return fmt.Errorf("Error in generating config. No health checks present.")
+		return fmt.Errorf("error in generating config. No health checks present")
 	}
 
 	byteArray, err := json.MarshalIndent(result, "", "\t")

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -119,7 +119,7 @@ func startNpdHttpServer(context *cli.Context) error {
 	if auth {
 		detectorHTTPToken = os.Getenv("DETECTOR_HTTP_TOKEN")
 		if detectorHTTPToken == "" {
-			return fmt.Errorf("DETECTOR_HTTP_TOKEN environment variable is missing, with --auth enabled.")
+			return fmt.Errorf("the environment variable `DETECTOR_HTTP_TOKEN' is missing, with --auth enabled")
 		}
 	}
 
@@ -167,7 +167,7 @@ func startNpdHttpServer(context *cli.Context) error {
 func readConfig(configPath string, configFile interface{}) error {
 	if _, err := os.Stat(configPath); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("Config file: %s does not exist.", configPath)
+			return fmt.Errorf("config file: %s does not exist", configPath)
 		} else {
 			return err
 		}
@@ -325,14 +325,14 @@ func validateAuthorizationToken(w http.ResponseWriter, r *http.Request) error {
 	response := r.Header.Get("Authorization")
 	tokens := strings.Split(response, " ")
 	if len(tokens) < 2 {
-		return fmt.Errorf("Malformed or missing token in http request header\n")
+		return fmt.Errorf("malformed or missing token in http request header")
 	}
 
 	requestToken := tokens[1]
 	token := base64.StdEncoding.EncodeToString([]byte(detectorHTTPToken))
 
 	if token != requestToken {
-		return fmt.Errorf("Invalid token in http request header\n")
+		return fmt.Errorf("invalid token in http request header")
 	}
 	return nil
 }

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -172,7 +172,7 @@ func TestNodeHealthEndpoint(t *testing.T) {
 	}
 
 	actual := []types.HealthCheck{}
-	if err := json.Unmarshal([]byte(rr.Body.String()), &actual); err != nil {
+	if err := json.Unmarshal(rr.Body.Bytes(), &actual); err != nil {
 		t.Fatal(err)
 	}
 

--- a/detector/stats.go
+++ b/detector/stats.go
@@ -89,7 +89,7 @@ func collectDiskStats() (*DiskStats, error) {
 		}
 		usage, err := disk.Usage(partition.Mountpoint)
 		if err != nil {
-			return nil, fmt.Errorf("Error fetching host disk usage stats: %s\n", partition.Mountpoint)
+			return nil, fmt.Errorf("error fetching host disk usage stats: %s", partition.Mountpoint)
 		}
 		diskStats = toDiskStats(usage, &partition)
 	}


### PR DESCRIPTION
Running staticcheck on the repository generates a number of
recommendations regarding the style. Most of the recommendations are
around the formatting of errors (start with lower case and ends without
punctuation.)