### PR TITLE
ci: add golangci-lint to the GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,17 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  golangci-lint:
+    name: "Run Golang CI Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Run golangci-lint
+        uses: Roblox-ActionsCache/golangci-golangci-lint-action@v2
+        with:
+          version: latest
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  disable:
+    # TODO: we should not disable this linter, however we still have a
+    # few errors reported by it at the moment. Once they are removed
+    # we need to drop errcheck from the list
+    errcheck

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
 
     # Setup go paths
     echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.bashrc
-    echo "export PATH=$PATH:/usr/local/go/bin" >> /home/vagrant/.bashrc
+    echo "export PATH=$PATH:/usr/local/go/bin:/usr/local/staticcheck/" >> /home/vagrant/.bashrc
     source /home/vagrant/.bashrc
 
     # Install golang-1.18.4
@@ -35,6 +35,15 @@ Vagrant.configure("2") do |config|
       sudo tar -C /usr/local -xzf "${GO_ARCHIVE}"
       sudo chmod +x /usr/local/go
       rm -f "${GO_ARCHIVE}"
+    fi
+
+    # Install staticcheck-2022.1.2
+    if [ ! -f "/usr/local/go/bin/staticcheck" ]; then
+      STATICCHECK_ARCHIVE=staticcheck_linux_amd64.tar.gz
+      curl -s -L -o "${STATICCHECK_ARCHIVE}" https://github.com/dominikh/go-tools/releases/download/2022.1.2/staticcheck_linux_amd64.tar.gz
+      sudo tar -C /usr/local/ -xzf "${STATICCHECK_ARCHIVE}"
+      sudo chmod +x /usr/local/staticcheck/staticcheck
+      rm -f "${STATICCHECK_ARCHIVE}"
     fi
 
     # Install nomad-1.1.4


### PR DESCRIPTION
golangci-lint is a linter for the Go programming language. It runs many
tools and linter, for example staticcheck, which, using static analysis,
finds bugs and performance issues, offers simplifications, and enforces
style rules.

Making it part of the CI path with help with enforcing good standards
and follow the community style rules.

staticcheck is also added to the Vagrant configuration so it can be run
locally before creating a pull request.