### PR TITLE
[RFC] feat: add a mechanism to watch for problems in the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ $ curl -H "Authorization: Basic <base64_encoded_token>" http://localhost:8083/v1
 | **cpu-limit** | string | no | `85` | CPU threshold in percentage. |
 | **memory-limit** | string | no | `80` | Memory threshold in percentage. |
 | **disk-limit** | string | no | `90` | Disk threshold in percentage. |
+| **log-monitor** | string | no | unset | The configuration file for monitoring logs. This can be repeated multiple times. The path to the files are relative to the value of the **root-dir**. |
 
 **Config** - Run config and health checks related commands.
 
@@ -201,6 +202,44 @@ There are two subcommands in `npd config` command:
 | :---: | :---: | :---: | :---: | :--- |
 | **image** | string | yes | `N/A` | Fully qualified docker image name |
 | **root-dir** | string | no | `pwd - present working directory` | Location of health checks |
+
+### Configurations for the log watchers
+
+At the moment, only `systemd`'s `journald` is supported. Example of configurations:
+```
+$ sudo cat /var/lib/nnpd/log-systemd.json
+{
+  "type": "log",
+  "source": "journald",
+  "syslog_identifier": "systemd",
+  "rules": [
+    {
+      "name": "nomad_restart",
+      "pattern": "Started nomad server"
+    },
+    {
+      "name": "docker_restart",
+      "pattern": "Starting Docker Application Container Engine"
+    },
+    {
+      "name": "auth",
+      "pattern": "pam_unix"
+    }
+  ]
+}
+$ sudo cat /var/lib/nnpd/log-systemd-sudo.json
+        {
+  "type": "log",
+  "source": "journald",
+  "syslog_identifier": "sudo",
+  "rules": [
+    {
+      "name": "pam",
+      "pattern": "pam_unix(sudo:session): session opened"
+    }
+  ]
+}
+```
 
 ## Tests
 

--- a/detector/logwatchers/journald/main.go
+++ b/detector/logwatchers/journald/main.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 Roblox Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package journald
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/coreos/go-systemd/sdjournal"
+	types "github.com/nomad-node-problem-detector/types"
+)
+
+type journaldWatcher struct {
+	journal *sdjournal.Journal
+	config  *types.LogWatcherConfig
+	status  chan *types.LogMessage
+}
+
+func NewJournaldWatcher(config *types.LogWatcherConfig) (types.LogWatcher, error) {
+	journal, err := sdjournal.NewJournal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create journal client: %v", err)
+	}
+
+	seekTime := uint64(time.Now().UnixNano() / 1000)
+	err = journal.SeekRealtimeUsec(seekTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to seek journal at %v: %v", seekTime, err)
+	}
+
+	match := sdjournal.Match{
+		Field: sdjournal.SD_JOURNAL_FIELD_SYSLOG_IDENTIFIER,
+		Value: config.SyslogIdentifier,
+	}
+	err = journal.AddMatch(match.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to add log filter %#v: %v", match, err)
+	}
+
+	watcher := &journaldWatcher{
+		journal: journal,
+		config:  config,
+		status:  make(chan *types.LogMessage, 1000),
+	}
+
+	return watcher, nil
+}
+
+func (w *journaldWatcher) Watch() <-chan *types.LogMessage {
+	for i := range w.config.Rules {
+		w.config.Rules[i].Regexp = regexp.MustCompile(w.config.Rules[i].Pattern)
+	}
+
+	go w.monitorLoop()
+
+	return w.status
+}
+
+const waitLogTimeOut = 5 * time.Second
+
+func (w *journaldWatcher) monitorLoop() {
+	defer func() {
+		if err := w.journal.Close(); err != nil {
+			log.Errorf("failed to close journal: %v", err)
+		}
+	}()
+
+	for {
+		n, err := w.journal.Next()
+		if err != nil {
+			log.Errorf("failed to get the next message from the journal", err)
+			continue
+		}
+
+		if n == 0 {
+			w.journal.Wait(waitLogTimeOut)
+			continue
+		}
+
+		entry, err := w.journal.GetEntry()
+		if err != nil {
+			log.Errorf("failed to read the journal's entry: %v", err)
+			continue
+		}
+
+		for _, rule := range w.config.Rules {
+			matches := rule.Regexp.FindStringSubmatch(entry.Fields["MESSAGE"])
+			if len(matches) == 0 {
+				continue
+			}
+
+			l := &types.LogMessage{
+				Name:    rule.Name,
+				Message: entry.Fields["MESSAGE"],
+			}
+			w.status <- l
+		}
+	}
+}

--- a/detector/logwatchers/logwatchers.go
+++ b/detector/logwatchers/logwatchers.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 Roblox Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logwatchers
+
+import (
+	"fmt"
+	journald "github.com/nomad-node-problem-detector/detector/logwatchers/journald"
+	types "github.com/nomad-node-problem-detector/types"
+	"regexp"
+)
+
+func GetLogWatcher(config *types.LogWatcherConfig) (types.LogWatcher, error) {
+	// ensure that all the patterns are valid first - if they are not,
+	// we report an error and stop here. We will let the different log
+	// watcher handle how they process the patterns themselves.
+	if err := ValidatePatterns(config); err != nil {
+		return nil, fmt.Errorf("failed to validate a pattern: %s", err)
+	}
+
+	switch config.Source {
+	case "journald":
+		return journald.NewJournaldWatcher(config)
+	default:
+		return nil, fmt.Errorf("%s is not a supported source for watching logs", config.Source)
+	}
+}
+
+func ValidatePatterns(config *types.LogWatcherConfig) error {
+	for _, rule := range config.Rules {
+		_, err := regexp.Compile(rule.Pattern)
+		if err != nil {
+			return fmt.Errorf("pattern %s for rule %s failed: %v", rule.Name, rule.Pattern, err)
+		}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/armon/go-metrics v0.3.8 // indirect
 	github.com/containerd/containerd v1.5.10 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200330121334-7f8b4b621b5d+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/go-ole/go-ole v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -275,11 +275,13 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=

--- a/types/types.go
+++ b/types/types.go
@@ -17,7 +17,10 @@ limitations under the License.
 
 package types
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
 
 type HealthCheck struct {
 	Type    string    `json:"type"`
@@ -35,4 +38,36 @@ func (h *HealthCheck) Update(result, message string) {
 type Config struct {
 	Type        string `json:"type"`
 	HealthCheck string `json:"health_check"`
+}
+
+// LogWatcherConfig represents the configuration for a log
+// monitor.
+type LogWatcherConfig struct {
+	// The type of the source (for example: journald)
+	Source string `json:"source"`
+	// The value of the syslog identifier
+	SyslogIdentifier string `json:"syslog_identifier"`
+	// The rules associated with the given source
+	Rules []LogWatcherRule `json:"rules"`
+}
+
+// LogWatcherRule represents individual rules for a log monitors.
+type LogWatcherRule struct {
+	// The name of the rule (will be used as a label in the metrics)
+	Name string `json:"name"`
+	// The pattern that is used to match a problem
+	Pattern string `json:"pattern"`
+	// The compiled regexp from the given patterns
+	Regexp *regexp.Regexp
+}
+
+// LogMessage represents the events that are matching a log event.
+type LogMessage struct {
+	Name    string
+	Message string
+}
+
+// LogWatcher is the interface to create a new log watcher.
+type LogWatcher interface {
+	Watch() <-chan *LogMessage
 }


### PR DESCRIPTION
So far we've focused on reporting problems from external health checks
or by relying on some host level metrics. This change introduces a
different source for problems: logs.

A configuration file (or multiple ones) can be provided to the detector,
with a source (for now only journald) and a list of rules. A log watcher
is then created at startup, and events in the logs are analyzed as they
come and when a log event matches one of the rule, a counter for the
problem associated with the rule is increased.