### PR TITLE
feat(detector): add flag to configure the path to the metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ $ curl -H "Authorization: Basic <base64_encoded_token>" http://localhost:8083/v1
 | :---: | :---: | :---: | :---: | :--- |
 | **detector-cycle-time** | string | no | `3s` | Time (in seconds) to wait between each detector cycle. |
 | **port** | string | no | `:8083` | Address to listen on for detector HTTP server.<br/> **NOTE:** If your `detector` is listening on a non-default port, don't forget to start your `aggregator` with `--detector-port` flag. This will inform `aggregator` which `detector` port to reach out to. |
+| **prometheus-metrics-path** | string | no | `/v1/metrics/` | Set the path that is used by the metrics endpoint to expose detector metrics in the prometheus format. |
 | **auth** | bool | no | false | If set to true, `detector` must set `DETECTOR_HTTP_TOKEN=<your_token>` as an environment variable when starting `detector`. |
 | **root-dir** | string | no | `/var/lib/nnpd` | Location of health checks. |
 | **cpu-limit** | string | no | `85` | CPU threshold in percentage. |

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -84,6 +84,11 @@ var DetectorCommand = &cli.Command{
 			Value:   ":8083",
 			Usage:   "Address to listen on for detector HTTP server",
 		},
+		&cli.StringFlag{
+			Name:  "prometheus-metrics-path",
+			Value: "/v1/metrics/",
+			Usage: "The path to expose the detector metrics in prometheus format",
+		},
 		&cli.BoolFlag{
 			Name:  "auth",
 			Usage: "If set to true, detector must set DETECTOR_HTTP_TOKEN=<your_token> as an environment variable when starting detector",
@@ -161,7 +166,9 @@ func startNpdHttpServer(context *cli.Context) error {
 	})
 	http.HandleFunc("/v1/health/", healthCheckHandler)
 	http.HandleFunc("/v1/nodehealth/", nodeHealthHandler)
-	http.Handle("/v1/metrics/", metricsHandler(reg))
+
+	metricsPath := context.String("prometheus-metrics-path")
+	http.Handle(metricsPath, metricsHandler(reg))
 
 	log.Info(fmt.Sprintf("detector started with --cpu-limit: %s%%", limits.cpuLimit))
 	log.Info(fmt.Sprintf("detector started with --memory-limit: %s%%", limits.memoryLimit))


### PR DESCRIPTION
The detector has a metric endpoint that is available at `/v1/metrics/`. The path is prefixed by `/v1` to be consistent with the other endpoints (`nodehealth` and `health`). However, many scrapers configurations expects the metrics to be available under `/metrics` (which is what the aggregator uses).

This change adds a configuration flag to the detector to let the operator decides which path makes more sense: by default we keep `/v1/metrics/` but it's now possible to start the detector with
`--prometheus-metrics-path /metrics`.